### PR TITLE
Feature/sim time

### DIFF
--- a/launch/dual_lidar.launch.py
+++ b/launch/dual_lidar.launch.py
@@ -5,7 +5,7 @@ from launch.substitutions import LaunchConfiguration
 
 def generate_launch_description():
     use_sim_time_arg = DeclareLaunchArgument(
-        'use_sim_time', default_value='true',
+        'use_sim_time', default_value='false',
         description='Use simulation time')
     return LaunchDescription([
         use_sim_time_arg,

--- a/launch/dual_lidar.launch.py
+++ b/launch/dual_lidar.launch.py
@@ -1,8 +1,14 @@
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
 from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
 
 def generate_launch_description():
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time', default_value='true',
+        description='Use simulation time')
     return LaunchDescription([
+        use_sim_time_arg,
         # Launch the first LidarPublisherNode
         Node(
             package='sensor_integration_suite',
@@ -10,9 +16,9 @@ def generate_launch_description():
             name='lidar_publisher_node_hz',
             parameters=[{'lidar_uri': '/dev/ttyUSB0', 
                          'topic_name': '/lidar/points_hz',
-                         'frame_id':'horizontal_laser_link'}],
-            output='screen',
-            prefix='xterm -e gdb --args'
+                         'frame_id':'horizontal_laser_link',
+                         'use_sim_time':LaunchConfiguration('use_sim_time')}],
+            output='screen'
         ),
         # Launch the second LidarPublisherNode
         Node(
@@ -21,8 +27,8 @@ def generate_launch_description():
             name='lidar_publisher_node_vt',
             parameters=[{'lidar_uri': '/dev/ttyUSB1', 
                          'topic_name': '/lidar/points_vt',
-                         'frame_id':'vertical_laser_link'}],
-            output='screen',
-            prefix='xterm -e gdb --args'
+                         'frame_id':'vertical_laser_link',
+                         'use_sim_time':LaunchConfiguration('use_sim_time')}],
+            output='screen'
         )
     ])

--- a/launch/frame_broadcaster.launch.py
+++ b/launch/frame_broadcaster.launch.py
@@ -31,13 +31,12 @@ def generate_launch_description():
             str(rotation[0]), str(rotation[1]), str(rotation[2]),
             parent_frame, child_frame
         ]
-        parameters=[{'use_sim_time': LaunchConfiguration('use_sim_time')}]
 
         transform_publishers.append(
             Node(
                 package='tf2_ros',
                 executable='static_transform_publisher',
-                parameters = parameters,
+                parameters = [{'use_sim_time': LaunchConfiguration('use_sim_time')}],
                 arguments=arguments
             )
         )

--- a/launch/frame_broadcaster.launch.py
+++ b/launch/frame_broadcaster.launch.py
@@ -1,11 +1,16 @@
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
+from launch.substitutions import LaunchConfiguration
 import yaml
 import os
 
 def generate_launch_description():
     # Load the YAML file with transform configurations
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time', default_value='true',
+        description='Use simulation time')
     config_directory = os.path.join(get_package_share_directory('sensor_integration_suite'))
     yaml_file = os.path.join(config_directory, 'frames.yaml')
     
@@ -33,5 +38,6 @@ def generate_launch_description():
                 arguments=arguments
             )
         )
+    transform_publishers.append(use_sim_time_arg)
 
     return LaunchDescription(transform_publishers)

--- a/launch/frame_broadcaster.launch.py
+++ b/launch/frame_broadcaster.launch.py
@@ -9,7 +9,7 @@ import os
 def generate_launch_description():
     # Load the YAML file with transform configurations
     use_sim_time_arg = DeclareLaunchArgument(
-        'use_sim_time', default_value='true',
+        'use_sim_time', default_value='false',
         description='Use simulation time')
     config_directory = os.path.join(get_package_share_directory('sensor_integration_suite'))
     yaml_file = os.path.join(config_directory, 'frames.yaml')

--- a/launch/frame_broadcaster.launch.py
+++ b/launch/frame_broadcaster.launch.py
@@ -19,6 +19,7 @@ def generate_launch_description():
 
     # Create a list of Node actions from the loaded configurations
     transform_publishers = []
+    transform_publishers.append(use_sim_time_arg)
     for transform in transforms_config:
         translation = transform['translation']
         rotation = transform['rotation']
@@ -30,14 +31,15 @@ def generate_launch_description():
             str(rotation[0]), str(rotation[1]), str(rotation[2]),
             parent_frame, child_frame
         ]
+        parameters=[{'use_sim_time': LaunchConfiguration('use_sim_time')}]
 
         transform_publishers.append(
             Node(
                 package='tf2_ros',
                 executable='static_transform_publisher',
+                parameters = parameters,
                 arguments=arguments
             )
         )
-    transform_publishers.append(use_sim_time_arg)
 
     return LaunchDescription(transform_publishers)

--- a/launch/sensor_integration.launch.py
+++ b/launch/sensor_integration.launch.py
@@ -8,7 +8,7 @@ import os
 
 def generate_launch_description():
     use_sim_time_arg = DeclareLaunchArgument(
-        'use_sim_time', default_value='true',
+        'use_sim_time', default_value='false',
         description='Use simulation time')
     camera_model_arg = LaunchConfiguration('camera_model', default='zedm')
     launch_file_dir = os.path.join(

--- a/launch/sensor_integration.launch.py
+++ b/launch/sensor_integration.launch.py
@@ -1,5 +1,5 @@
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir
 from ament_index_python.packages import get_package_share_directory
@@ -7,6 +7,9 @@ from launch_ros.actions import Node
 import os
 
 def generate_launch_description():
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time', default_value='true',
+        description='Use simulation time')
     camera_model_arg = LaunchConfiguration('camera_model', default='zedm')
     launch_file_dir = os.path.join(
         get_package_share_directory('zed_wrapper'),
@@ -20,12 +23,15 @@ def generate_launch_description():
         # IncludeLaunchDescription(
         #     PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/frame_broadcaster.launch.py'])
         # ),
+        use_sim_time_arg,
         IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([sensor_integration_dir, '/dual_lidar.launch.py'])
+            PythonLaunchDescriptionSource([sensor_integration_dir, '/dual_lidar.launch.py']),
+        launch_arguments={'use_sim_time': LaunchConfiguration('use_sim_time')}.items(),
         ),
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([launch_file_dir, '/zed_camera.launch.py']),
-            launch_arguments={'camera_model': camera_model_arg}.items()
+            launch_arguments={'camera_model': camera_model_arg,
+                              'use_sim_time':LaunchConfiguration('use_sim_time')}.items()
         ),
         Node(
             package='sensor_integration_suite',
@@ -33,7 +39,8 @@ def generate_launch_description():
             name='pointcloud_fusion_node',
             parameters=[{'zed_cloud_topic_name': '/zed/zed_node/point_cloud/cloud_registered', 
                          'vertical_pc_topic_name': '/lidar/points_vt',
-                         'horizontal_pc_topic_name':'/lidar/points_hz'}],
+                         'horizontal_pc_topic_name':'/lidar/points_hz',
+                         'use_sim_time':LaunchConfiguration('use_sim_time')}],
             output='screen'
         ),
 


### PR DESCRIPTION
Added the ability to use the use_sim_time as an argument to launch files, this also requires a simulated enviroment to be launched, for that you can launch gazebo seperately by following command
```bash
ros2 launch gazebo_ros gazebo.launch.py
```
then launch any other required file 